### PR TITLE
Improve crossing and dossing filter

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,15 +60,25 @@ function getUrlParameters(url: string): object
 async function crossEndoDoss(endo: boolean)
 {
     const nations: string[] = [];
-    const lis: NodeList = document.querySelectorAll('li');
-    for (let i = 0; i < lis.length; i++) {
-        const li: HTMLUListElement = lis[i] as HTMLUListElement;
-        const nationName: string = canonicalize(li.querySelector('.nnameblock').innerHTML);
-        if (li.innerHTML.indexOf('was admitted') !== -1)
+    const processedNations = new Set();
+    const lis = document.querySelectorAll('li');
+    lis.forEach((li) => {
+        // ignore non-World Assembly happenings
+        if (!li.textContent.includes("World Assembly"))
+            return;
+        
+        const nationName = canonicalize(li.querySelector('.nnameblock').textContent);
+
+        // only check the most recent World Assembly happening for each nation
+        if (processedNations.has(nationName))
+            return;
+        
+        if (li.textContent.includes("was admitted"))
             nations.push(nationName);
-        else if (li.innerHTML.indexOf('resigned') !== -1)
-            nations.splice(nations.indexOf(nationName), 1);
-    }
+        
+        processedNations.add(nationName);
+    });
+
     if (endo)
         await setStorageValue('nationstoendorse', nations);
     else

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ const keybinds: Keybind[] = [
         },
         modifiedCallback: async () => {
             if (urlParams['view'] === `region.${await getStorageValue('jp')}`) {
+                console.log("crossEndoDoss")
                 await crossEndoDoss(true);
             }
             else if (urlParams['nation']) {


### PR DESCRIPTION
Gauntlet's current method for creating a list of which nations to cross or doss from an activity page is to go through the happenings sequentially, add a nation to the list if the happening is a WA admit, and remove a nation from the list if the happening is a WA resignation. This doesn't quite work for nations that have joined and resigned from the WA, which are usually nations from the previous update or that have switched already.

Since the activity feed shows happenings starting with the most recent, Gauntlet will process the more recent WA resignation first and then the WA admit, so those nations will be counted even though they're no longer in the WA. Actually, it's a little worse than that; nations are currently removed from the list by `splice()`-ing the `indexOf()` the nation in the happening, which is problematic since `indexOf` can return `-1`. In those cases, Gauntlet is actually just removing the last nation it counted whenever it processes a WA resignation happening for a nation it hasn't yet counted.

This PR instead checks just the first WA happening for each nation present. If that happening is a WA admit, the nation is added to the list. I think this should work because we only need to consider the current WA status of each nation. I know this also doesn't count situations where the most recent WA happening is an application, but I'm not aware of any way to apply to the WA while already being a member (though I may be wrong about that).