### PR TITLE
Add WA resignation keybind

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -295,6 +295,27 @@ const keybinds: Keybind[] = [
             history.back();
         },
         modifiedCallback: null
+    },
+    {
+        functionName: 'resign',
+        displayName: "Resign from WA",
+        defaultKey: "'",
+        callback: () => {
+            // if not a WA member
+            if (urlParams['page'] === 'un' && document.querySelector("input[value='join_UN']")) {
+                notyf.error("It doesn't seem like you're in the WA.");
+                return;
+            }
+
+            const chkInput: HTMLInputElement | null = document.querySelector("input[name=chk]");
+
+            if (chkInput) {
+                location.assign(`/page=UN_status?action=leave_UN&chk=${chkInput.value}&submit=1`);
+            } else {
+                location.assign("/page=un");
+            }
+        },
+        modifiedCallback: null
     }
 ];
 


### PR DESCRIPTION
This PR adds a keybind for resigning from the WA.

We have a keybind for prepping already, which on Breeze++ doubles as a keybind for switching, but since Gauntlet goes through your switchers for you when prepping, there isn't a keybind just for resigning on the currently logged-in switcher in order to join the WA on the next one.

(I probably should have caught this one earlier, oops 😛)