### PR TITLE
Return to activity page after crossing and dossing

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,6 +47,17 @@ async function setStorageValue(key: string, value: any): Promise<void>
     });
 }
 
+async function removeStorageValue(key: string | string[]): Promise<void>
+{
+    return new Promise((resolve) =>
+    {
+        chrome.storage.local.remove(key, () => 
+        {
+            resolve();
+        })
+    })
+}
+
 function getUrlParameters(url: string): object
 {
     const reg: RegExp = new RegExp('\/([A-Za-z0-9-]+?)=([A-Za-z0-9_.+-]+)', 'g');


### PR DESCRIPTION
Closes #11 

I ended up going with a success notification rather than pop-up, partly because calling `notyf.success()` was easier than making a pop-up 😛. But also I think there is a use case for quickly cross-endorsing or dossing from the activity feed again (e.g. a user switches and cross-endorses quickly, then sees there are newer admits on their activity feed that they didn't endorse) where saving a keybind to dismiss a pop-up would be more ergonomic.