### PR TITLE
Use login form while prepping

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -86,3 +86,9 @@ async function crossEndoDoss(endo: boolean)
     if (nations.length > 0)
         window.location.href = `/template-overall=none/nation=${nations[0]}`;
 }
+
+function login(nation: string, password: string) {
+    document.querySelector<HTMLInputElement>("#loginbox > form input[name=nation]").value = nation;
+    document.querySelector<HTMLInputElement>("#loginbox > form input[name=password]").value = password;
+    document.querySelector<HTMLButtonElement>("#loginbox > form button[name=submit]").click();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,25 +251,29 @@ const keybinds: Keybind[] = [
                 if (resendButton !== null)
                     resendButton.click();
                 else
-                    window.location.href = `/template-overall=none/region=${jumpPoint}`;
+                    window.location.href = `/region=${jumpPoint}`;
             }
             else if (urlParams['region'] === jumpPoint && moveButton !== null)
                 moveButton.click();
             else if (urlParams['page'] === 'change_region' || (urlParams['region'] && moveButton === null)) {
-                if (currentSwitcher === (switchers.length - 1)) {
-                    await setStorageValue('currentswitcher', 0);
-                    window.location.href =
-                        `/template-overall=none/page=un?nation=${switchers[0]}&password=${password}&logging_in=1`;
-                }
-                else {
-                    await setStorageValue('currentswitcher', currentSwitcher + 1);
-                    window.location.href =
-                        `/template-overall=none/page=un?nation=${switchers[currentSwitcher + 1]}&password=${password}&logging_in=1`;
-                }
+                const nextSwitcher = currentSwitcher === (switchers.length - 1) ? 0 : currentSwitcher + 1;
+                await setStorageValue('currentswitcher', nextSwitcher);
+                if (document.querySelector("#loginbox"))
+                    login(switchers[nextSwitcher], password);
+                else
+                    location.assign("/page=blank/gauntlet=login");
+            }
+            else if (urlParams["gauntlet"] === "login") {
+                login(switchers[currentSwitcher], password);
+            }
+            else if (urlParams["nation"] === canonicalize(switchers[currentSwitcher]) && document.body.dataset?.nname === switchers[currentSwitcher]) {
+                location.assign("/template-overall=none/page=un");
+            }
+            else if (document.querySelector("#loginbox")) {
+                login(switchers[currentSwitcher], password);
             }
             else {
-                window.location.href =
-                    `/template-overall=none/page=un?nation=${switchers[currentSwitcher]}&password=${password}&logging_in=1`;
+                location.assign("/page=blank/gauntlet=login");
             }
         },
         modifiedCallback: async () =>


### PR DESCRIPTION
Fixes #19 

This PR uses the login/switching form built into the NationStates site while prepping, instead of sending passwords as search parameters.