### PR TITLE
Use no-template pages when resigning WA

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -330,9 +330,9 @@ const keybinds: Keybind[] = [
             const chkInput: HTMLInputElement | null = document.querySelector("input[name=chk]");
 
             if (chkInput) {
-                location.assign(`/page=UN_status?action=leave_UN&chk=${chkInput.value}&submit=1`);
+                location.assign(`/template-overall=none/page=UN_status?action=leave_UN&chk=${chkInput.value}&submit=1`);
             } else {
-                location.assign("/page=un");
+                location.assign("/template-overall=none/page=un");
             }
         },
         modifiedCallback: null


### PR DESCRIPTION
Fixes #25 

This one's a very minor code change. I'll note that I didn't apply MVP.css styles or any other prettification to the no-template WA page or resignation success page — they feel decently readable to me, especially for a keybind that I'm expecting to mostly be used when switching, where users wouldn't be spending much time looking at those pages anyway.