### PR TITLE
Parse URL parameters in path only

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -61,9 +61,10 @@ async function removeStorageValue(key: string | string[]): Promise<void>
 function getUrlParameters(url: string): object
 {
     const reg: RegExp = new RegExp('\/([^\/]+?)=([^\/]+?)(?=$|\/)', 'g');
+    const path = new URL(url).pathname;
     let params: object = {};
     let match: string[];
-    while ((match = reg.exec(url)) !== null)
+    while ((match = reg.exec(path)) !== null)
         params[match[1]] = match[2];
     return params;
 }


### PR DESCRIPTION
So, turns out #27 broke URL parameter parsing for links containing search parameters. (Oops.)

We could also parse URL search parameters as well — for instance, both www.nationstates.net/?nation=testlandia and www.nationstates.net/nation=testlandia are working links, and I _think_ the server parses both equivalently — but for now I've just gone with parsing only URL parameters in the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/Location#location_anatomy) of URLs which seems a bit more conventional.