### PR TITLE
Clear search parameters

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -397,4 +397,8 @@ document.addEventListener('keyup', (e: KeyboardEvent) =>
         currentPage.searchParams.delete("gauntlet-success");
         window.history.replaceState({}, '', currentPage); // use replaceState to avoid page reload
     }
+
+    // remove all query parameters to prevent form re-submission, repeat messages, etc.
+    currentPage.search = "";
+    window.history.replaceState({}, '', currentPage);
 })();


### PR DESCRIPTION
Closes #28 

I went the route of just clearing [all search parameters](https://github.com/libcord-tech/gauntlet/issues/28#issuecomment-1610937737) — we already did this for Gauntlet-specific parameters, to avoid repeated toasts. It doesn't seem like we've used search parameters for anything other than those toasts and for data submission, but it's probably best if I do some testing and see if it breaks anything.