### PR TITLE
Create workflow for continuous integration builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,49 @@
+name: Nightly Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Zip build directory
+        run: zip -r gauntlet-nightly.zip build/
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly-${{ github.sha }}
+          release_name: Nightly Build ${{ github.sha }}
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./gauntlet-nightly.zip
+          asset_name: gauntlet-nightly.zip
+          asset_content_type: application/zip

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm ci
@@ -40,9 +40,9 @@ jobs:
           prerelease: true
           body: |
             ⚠️ Gauntlet Nightly - Unstable Release ⚠️
-            
+
             This is a nightly build generated from the latest code. It is provided for users who are fine with bugs and want to have the latest features. It may contain bugs and incomplete features. Use it at your own risk.
-            
+
             For the latest stable release, please look at the [Releases](https://github.com/libcord-tech/gauntlet/releases/latest) page.
 
       - name: Upload Release Asset

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly-${{ github.sha }}
-          release_name: Nightly Build ${{ github.sha }}
+          release_name: Gauntlet Nightly ${{ github.sha }}
           draft: false
           prerelease: true
           body: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -37,6 +37,12 @@ jobs:
           release_name: Nightly Build ${{ github.sha }}
           draft: false
           prerelease: true
+          body: |
+            ⚠️ Gauntlet Nightly - Unstable Release ⚠️
+            
+            This is a nightly build generated from the latest code. It is provided for users who are fine with bugs and want to have the latest features. It may contain bugs and incomplete features. Use it at your own risk.
+            
+            For the latest stable release, please look at the [Releases](https://github.com/libcord-tech/gauntlet/releases/latest) page.
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@types/chrome": "^0.0.209",
         "run-for-every-file": "^1.1.0",
-        "terser": "^5.16.1"
+        "terser": "^5.16.1",
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -284,6 +285,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -515,6 +529,12 @@
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       }
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "npx tsc --watch",
-    "build:compile": "npx tsc",
+    "dev": "tsc --watch",
+    "build:compile": "tsc",
     "build:minify": "run-for-every-file --src ./build/scripts/ --dest ./build/scripts/ --file \"*.js\" --run \"terser {{src-file}} --compress --mangle -o {{src-file}}\"",
     "build": "npm run build:compile && npm run build:minify"
   },
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.209",
     "run-for-every-file": "^1.1.0",
-    "terser": "^5.16.1"
+    "terser": "^5.16.1",
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
This workflow will create a new pre-release every time there's a push to the main branch.

I think this would be good for anyone who wants to stay up to date with what we're working on without having to wait for us to make a full release.

Technically, these should probably be called CI builds, but nightly is probably more user friendly. :p