### PR TITLE
Fix deprecation warning for get current date step

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,15 +31,15 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H%M')"
+        run: echo "DATE=$(date +'%Y-%m-%d-%H%M')" >> $GITHUB_ENV
 
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           artifacts: "gauntlet-nightly.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: nightly-${{ steps.date.outputs.date }}
-          name: Gauntlet Nightly ${{ steps.date.outputs.date }}
+          tag: nightly-${{ env.DATE }}
+          name: Gauntlet Nightly ${{ env.DATE }}
           body: |
             ⚠️ Gauntlet Nightly - Unstable Release ⚠️
 


### PR DESCRIPTION
Apparently I added another deprecation by fixing the other deprecated steps, but this should be the last of them.