### PR TITLE
Update version to 0.10 for release

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gauntlet",
-  "version": "0.9",
+  "version": "0.10",
   "description": "Defend easier in NationStates.",
   "author": "Haku",
   "permissions": ["activeTab", "storage", "tabs"],


### PR DESCRIPTION
Given #58 landed changes for legality, I think a new release is best, so we don't need to encourage folks to switch from a 'stable' to a 'nightly' version.